### PR TITLE
Ensure that a treesit parser exists for the current buffer

### DIFF
--- a/testrun.el
+++ b/testrun.el
@@ -136,6 +136,9 @@
 
 (defun testrun--go-test-command-at-point ()
   "Return the test command at point for Go."
+  ;; Unless there is a `treesit-parser' already, create one.
+  (unless (treesit-parser-list)
+    (treesit-parser-create 'go))
   (let ((c (testrun--go-recognize-test-chain)))
     (if c
         (format "go test -test.run %s"
@@ -152,7 +155,7 @@
   "Pick a backend for the current major mode."
   (let ((selected-backend nil))
     (dolist (backend testrun-backends)
-      (when (equal major-mode (plist-get backend :mode))
+      (when (derived-mode-p (plist-get backend :mode))
         (setq selected-backend (plist-get backend :backend))))
     (if selected-backend
         selected-backend


### PR DESCRIPTION
If you don't use other `treesit` modes in Go, this is necessary. Otherwise `testrun-at-point` errors with:

```
Error in post-command-hook (treesit-inspect-node-at-point): (treesit-no-parser #<buffer types_test.go>)
```